### PR TITLE
Cosmetic improvement and fix jp2a error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ declare -r SCRIPT_LOGFILE="/tmp/nodemaster_${DATE_STAMP}_out.log"
 declare -r IPV4_DOC_LINK="https://www.vultr.com/docs/add-secondary-ipv4-address"
 declare -r DO_NET_CONF="/etc/network/interfaces.d/50-cloud-init.cfg"
 
-apt-get install -qq jp2a
+apt-get install -qq jp2a -y
 function showbanner() {
 cat << "EOF"
  ███╗   ██╗ ██████╗ ██████╗ ███████╗███╗   ███╗ █████╗ ███████╗████████╗███████╗██████╗

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ declare -r SCRIPT_LOGFILE="/tmp/nodemaster_${DATE_STAMP}_out.log"
 declare -r IPV4_DOC_LINK="https://www.vultr.com/docs/add-secondary-ipv4-address"
 declare -r DO_NET_CONF="/etc/network/interfaces.d/50-cloud-init.cfg"
 
+apt-get install -qq jp2a
 function showbanner() {
 cat << "EOF"
  ███╗   ██╗ ██████╗ ██████╗ ███████╗███╗   ███╗ █████╗ ███████╗████████╗███████╗██████╗
@@ -572,9 +573,9 @@ function print_logo() {
 	# print ascii banner if a logo exists
 	echo -e "* Starting the compilation process for ${CODENAME}, stay tuned"
 	if [ -f "${SCRIPTPATH}/assets/$CODENAME.jpg" ]; then
-			jp2a -b --colors --width=56 ${SCRIPTPATH}/assets/${CODENAME}.jpg
+			jp2a -b --colors --width=78 ${SCRIPTPATH}/assets/${CODENAME}.jpg
 	else
-			jp2a -b --colors --width=56 ${SCRIPTPATH}/assets/default.jpg          
+			jp2a -b --colors --width=78 ${SCRIPTPATH}/assets/default.jpg          
 	fi  
 
 }
@@ -604,9 +605,9 @@ function build_mn_from_source() {
                 # print ascii banner if a logo exists
                 echo -e "* Starting the compilation process for ${CODENAME}, stay tuned"
                 if [ -f "${SCRIPTPATH}/assets/$CODENAME.jpg" ]; then
-                        jp2a -b --colors --width=56 ${SCRIPTPATH}/assets/${CODENAME}.jpg
+                        jp2a -b --colors --width=78 ${SCRIPTPATH}/assets/${CODENAME}.jpg
                 else
-                        jp2a -b --colors --width=56 ${SCRIPTPATH}/assets/default.jpg
+                        jp2a -b --colors --width=78 ${SCRIPTPATH}/assets/default.jpg
                 fi
                 # compilation starts here
                 source ${SCRIPTPATH}/config/${CODENAME}/${CODENAME}.compile | pv -t -i0.1


### PR DESCRIPTION
Quietly install jp2a before display of first banner to prevent first install error, adjust width of helium logo to achieve better resolution.